### PR TITLE
Exchange of messages between agents with sessions

### DIFF
--- a/pade/core/new_ams.py
+++ b/pade/core/new_ams.py
@@ -222,6 +222,7 @@ class CompVerifyRegister(FipaRequestProtocol):
                                              'content': validation}))
                     self.agent.send(reply)
 
+
 class AMS(Agent_):
     """This is the class that implements the AMS agent."""
 
@@ -230,9 +231,15 @@ class AMS(Agent_):
     user_login = dict()
     ams_debug = False
 
-    def __init__(self, host='localhost', port=8000, main_ams=True, debug=False):
+    def __init__(self, host='localhost', session=None, port=8000, main_ams=True, debug=False):
 
-        self.session_name = str(uuid.uuid1())[:13]
+        # Added session parameter
+        if session is None:
+            self.session_name = str(uuid.uuid1())[:13]
+        else:
+            self.session_name = session.name
+            self.session = session
+
         self.ams = {'name': host, 'port': port}
 
         self.ams_aid = AID('ams@' + str(host) + ':' + str(port))
@@ -310,6 +317,7 @@ class AMS(Agent_):
         # in case there is a session with this name
         else:
             self._verify_user_in_session(self.session)
+
 
 if __name__ == '__main__':
 

--- a/pade/core/new_ams.py
+++ b/pade/core/new_ams.py
@@ -147,8 +147,9 @@ class PublisherBehaviour(FipaSubscribeProtocol):
             # prepares and sends the update message to
             # all registered agents.
             if self.STATE == 0:
-                reactor.callLater(10.0, self.notify)
                 self.STATE = 1
+                # Try to notify the agents with the new changes in the moment they are produced
+                self.notify()
 
     @inlineCallbacks
     def register_agent_in_db(self, sql_act):

--- a/pade/misc/common.py
+++ b/pade/misc/common.py
@@ -216,7 +216,6 @@ class PadeSession(object):
             print(reactor)
             reactor.run()
 
-
     def __listen_agent(self, agent):
         reactor.callInThread(self._listen_agent, agent)
 

--- a/pade/misc/common.py
+++ b/pade/misc/common.py
@@ -206,14 +206,12 @@ class PadeSession(object):
             # 
             self._initialize_database()
 
-            i = 1.0
-            agents_process = list()
             for agent in self.agents:
-                a = AgentProcess(agent, self.ams, i)
-                # a.daemon = True
-                a.start()
-                agents_process.append(a)
-                i += 0.1
+                agent.update_ams(agent.ams)
+                agent.on_start()
+                ilp = reactor.listenTCP(agent.aid.port, agent.agentInstance)
+                agent.ILP = ilp
+
             print('-----')
             print(reactor)
             reactor.run()


### PR DESCRIPTION
In order to enable the exchange of messages between agents while executing a code like the following:

```
from pade.acl.aid import AID
from pade.misc.common import PadeSession
from agents.prosumer_agent import AgentProsumer
from agents.consumer_agent import AgentConsumer

def config_agents():
    agents = list()

    port_prosumer = 8500
    agent_prosumer_name = 'agent_prosumer_{}@localhost:{}'.format(port_prosumer, port_prosumer)
    agent_prosumer = AgentProsumer(AID(name=agent_prosumer_name))
    agents.append(agent_prosumer)

    port_consumer = 8501
    agent_consumer_name = 'agent_consumer_{}@localhost:{}'.format(port_consumer, port_consumer)
    agent_consumer = AgentConsumer(AID(name=agent_consumer_name))
    agents.append(agent_consumer)

    # Declaration of the PadeSession object
    pade_session = PadeSession()
    # Addition of the list of agents
    pade_session.add_all_agents(agents)
    # Registration of users on the platform
    pade_session.register_user(username='yeraymm', email='yeraymm@usal.es', password='12345')

    return pade_session


if __name__ == '__main__':

    s = config_agents()
    # initialization of the execution loop of the agents
    s.start_loop()
```

I have made changes to:
    - core/new_ams.py: in order to allow the use of initialized sessions in the AMS constructor
    - misc/common.py: to fix a bug in the in the loop that starts agents which call AgentProcess, a non-defined function.
    - core/new_ams.py: to update the table of addresses of each agent in the platform without waiting.

