### PR TITLE
ACLMessage.content can now be an ElementTree or a string

### DIFF
--- a/pade/acl/messages.py
+++ b/pade/acl/messages.py
@@ -227,8 +227,12 @@ class ACLMessage(ET.Element):
             self.add_reply_to(AID(name=aid))
 
     def set_content(self, data):
-        self.content = data
-        self.find('content').text = str(data)
+        if isinstance(data, ET.Element):
+            self.content = data
+            self.find('content').append(data)
+        else:
+            self.content = data
+            self.find('content').text = self.content
 
     def set_language(self, data):
         self.language = data

--- a/pade/core/sniffer.py
+++ b/pade/core/sniffer.py
@@ -37,6 +37,7 @@ from twisted.internet import reactor
 from sqlalchemy import create_engine, MetaData, Table
 
 from pickle import loads, dumps
+import xml.etree.ElementTree as ET
 import random
 import os
 import sys
@@ -79,6 +80,9 @@ class Sniffer(Agent):
 
             for message in messages:
                 receivers = ';'.join([i.localname for i in message.receivers])
+                content = message.content
+                if isinstance(content, ET.Element):
+                    content = ET.tostring(content)
 
                 insert_obj = MESSAGES.insert()
                 sql_act = insert_obj.values(agent_id=self.agent_db_id[sender],
@@ -86,7 +90,7 @@ class Sniffer(Agent):
                                             date=message.datetime,
                                             performative=message.performative,
                                             protocol=message.protocol,
-                                            content=message.content,
+                                            content=content,
                                             conversation_id=message.conversation_id,
                                             message_id=message.messageID,
                                             ontology=message.ontology,


### PR DESCRIPTION
Previously only strings were allowed, now it is possible to embed an ElementTree into the ACLMessage tree. It is useful when a message content is an XML document (represented by an ElementTree). The entire ACLMessage DOM will be sent through Twisted as usual.

Files changed:
- pade/acl/messages.py
```
def set_content(self, data):
    if isinstance(data, ET.Element):
        self.content = data
        self.find('content').append(data)
    else:
        self.content = data
        self.find('content').text = self.content
```
- pade/core/sniffer.py
```
for message in messages:
    receivers = ';'.join([i.localname for i in message.receivers])
    content = message.content
    if isinstance(content, ET.Element):
        content = ET.tostring(content)

    insert_obj = MESSAGES.insert()
    sql_act = insert_obj.values(agent_id=self.agent_db_id[sender],
                                sender=message.sender.name,
                                date=message.datetime,
                                performative=message.performative,
                                protocol=message.protocol,
                                content=content,
                                conversation_id=message.conversation_id,
                                message_id=message.messageID,
                                ontology=message.ontology,
                                language=message.language,
                                receivers=receivers)
```

OBS: This may have consequences to the visualization of message contents on Web Browser sessions