### PR TITLE
Retira parâmetros na chamada de super

### DIFF
--- a/docs/user/um-momento.rst
+++ b/docs/user/um-momento.rst
@@ -20,7 +20,7 @@ No código a seguir o *call_later()* é utilizado na classe *HelloAgent()* no m�
 
     class HelloAgent(Agent):
         def __init__(self, aid):
-            super(HelloAgent, self).__init__(aid=aid, debug=False)
+            super().__init__(aid=aid, debug=False)
 
         def on_start(self):
             super().on_start()


### PR DESCRIPTION
Argumentos passados para super não são necessários; Corrigido para manter consistência.