### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ THE SOFTWARE."""
 
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf8') as fh:
     long_description = fh.read()
 
 setup(name='pade',


### PR DESCRIPTION
encoding error when installing using setup.py in python 3.7, this fixes the issue