### PR TITLE
Avoid file encoding error when installing pade on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ THE SOFTWARE."""
 
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='UTF-8') as fh:
     long_description = fh.read()
 
 setup(name='pade',


### PR DESCRIPTION
This little patch declares explicitly the README.md encoding when using open() during installation, 
since this funtion expects 'UTF-8' by default in Linux but 'ANSI' in Windows.

This fix makes pade able to be installed in both Windows and Linux machines (I properly tested on both).
Before, when installing on Windows, it led to an error of file encoding.

For more information:
https://www.python.org/dev/peps/pep-0597/