### PR TITLE
Added handle_failure method to FIPA protocols

### DIFF
--- a/pade/behaviours/protocols.py
+++ b/pade/behaviours/protocols.py
@@ -413,6 +413,15 @@ class FipaContractNetProtocol(FipaProtocol):
         """
         pass
 
+    def handle_failure(self, message):
+        """This method should be overridden when implementing a protocol.
+            This method is always executed when the agent receives a 
+            FIPA_FAILURE type message 
+
+            :param message: FIPA-ACL message
+        """
+        pass
+
     def handle_reject_propose(self, message):
         """This method should be overridden when implementing a protocol.
             This method is always executed when the agent receives a
@@ -573,6 +582,13 @@ class FipaSubscribeProtocol(FipaProtocol):
     def handle_inform(self, message):
         """
             handle_inform
+
+        """
+        pass
+
+    def handle_failure(self, message):
+        """
+            handle_failure
 
         """
         pass

--- a/pade/behaviours/protocols.py
+++ b/pade/behaviours/protocols.py
@@ -131,8 +131,8 @@ class FipaProtocol(Behaviour):
         self.is_initiator = is_initiator
         self.message = message
 
-        self.filter_not_undestood = Filter()
-        self.filter_not_undestood.set_performative(ACLMessage.NOT_UNDERSTOOD)
+        self.filter_not_understood = Filter()
+        self.filter_not_understood.set_performative(ACLMessage.NOT_UNDERSTOOD)
 
         if self.message is not None:
             self.filter_conversation_id = Filter()
@@ -158,7 +158,7 @@ class FipaProtocol(Behaviour):
 
         self.message = message
 
-        if self.filter_not_undestood.filter(self.message):
+        if self.filter_not_understood.filter(self.message):
             self.handle_not_understood(message)
 
 class FipaRequestProtocol(FipaProtocol):
@@ -249,8 +249,8 @@ class FipaRequestProtocol(FipaProtocol):
     def handle_inform(self, message):
         """
         This method should be overridden when implementing a protocol.
-            This method is always executed when the agent receives a
-            FIPA_IMFORM type message
+            This method is always executed when the agent receives a 
+            FIPA_INFORM type message 
 
             :param message: FIPA-ACL message
         """


### PR DESCRIPTION
Little fix to implement the lacking handle_failure method to FIPA-Subscribe and FIPA-ContractNet protocols.
(This patch includes minor fixes to some misspellings in protocols.py file)