### PR TITLE
feat: New twisted.reactor call_from_thread method

### DIFF
--- a/pade/misc/utility.py
+++ b/pade/misc/utility.py
@@ -39,19 +39,36 @@ def display_message(name, data):
 
 
 def call_in_thread(method, *args):
+    """
+        Call blocking method in another thread
+    """
     reactor.callInThread(method, *args)
 
 
 def call_later(time, method, *args):
+    """
+        Call method in reactor thread after timeout
+    """
     return reactor.callLater(time, method, *args)
 
 
 def defer_to_thread(block_method, result_method, *args):
+    """
+        Call blocking method in another thread passing callback
+    """
     d = threads.deferToThread(block_method, *args)
     d.addCallback(result_method)
 
 
+def call_from_thread(method, *args):
+    """
+        Call reactor method (usually not thread safe) from thread
+    """
+    reactor.callFromThread(method, *args)
+
+
 def start_loop(agents):
+    """Start reactor thread main loop"""
     reactor.suggestThreadPoolSize(30)
     for agent in agents:
         agent.update_ams(agent.ams)


### PR DESCRIPTION
This commit implements the `call_from_thread` method, which points to `reactor.callFromThread` method.

Call_from_thread is a method necessary when we need to call any reactor method (e.g. for an agent to send a message) from another thread that has been launched with the call_in_thread method.

As specified in twisted docs, "[...] _Methods within Twisted may only be invoked from the reactor thread unless otherwise noted. Very few things within Twisted are thread-safe. For example, writing data to a transport from a protocol is not thread-safe. This means that if you start a thread and call a Twisted method, you might get correct behavior… or you might get hangs, crashes, or corrupted data. So don’t do it._" ([Using Threads in Twisted](https://twistedmatrix.com/documents/current/core/howto/threading.html))

The `call_from_thread` method works in pair with `call_in_thread` and ensures that any reactor method is only executed in the reactor thread.

**Edit 1**: This functionality could be achieved with defer_to_thread method, but it would require writing a callback function, which kills the context of the thread:
- Example 1: Using call_from_thread
```python
def blocking_method():
    a, b = 1, 2
    # Blocking part
    time.sleep(10)
    # Send message
    message = ACLMessage()
    # ...
    call_from_thread(self.send, message)
    # ... continue code, possible using `a`, `b` or `message` variables
    c = a + b
    # ...
# Launch a thread for blocking method
call_in_thread(blocking_method)
```
- Example 2: Using defer_to_thread
```python
def blocking_method():
    a, b = 1, 2
    # Blocking part
    time.sleep(10)
    # Send message
    message = ACLMessage()
    return message
def callback(message):
    # Executed in reactor thread
    self.send(message)
    # No more access to context, such as `a`, `b` variables
# Launch a thread for blocking method
defer_to_thread(blocking_method, callback)
```
A solution would be passing all necessary variables as argument to `callback`, but it wouldn't be a pythonic way to do it at all.