### PR TITLE
fix: Misspelling `enconding` word

### DIFF
--- a/docs/locale/en/LC_MESSAGES/user.po
+++ b/docs/locale/en/LC_MESSAGES/user.po
@@ -418,7 +418,7 @@ msgstr "*language:* language used in the message content;"
 
 #: ../../user/enviando-mensagens.rst:13
 msgid "*encoding:* codificação da mensagem;"
-msgstr "*enconding:* message codification;"
+msgstr "*encoding:* message codification;"
 
 #: ../../user/enviando-mensagens.rst:14
 msgid "*ontology:* ontologia utilizada;"

--- a/docs/user/enviando-mensagens.rst
+++ b/docs/user/enviando-mensagens.rst
@@ -82,7 +82,7 @@ Mas também é possível obter a mensagem no formato XML por meio do comando `pr
             <reply-to/>
             <content>Ola Agente</content>
             <language/>
-            <enconding/>
+            <encoding/>
             <ontology/>
             <protocol>fipa-request protocol</protocol>
             <conversationID>b2e806b8-50a0-11e5-b3b6-e8b1fc5c3cdf</conversationID>

--- a/pade/acl/messages.py
+++ b/pade/acl/messages.py
@@ -98,7 +98,7 @@ class ACLMessage(ET.Element):
         self.append(ET.Element('reply-to'))
         self.append(ET.Element('content'))
         self.append(ET.Element('language'))
-        self.append(ET.Element('enconding'))
+        self.append(ET.Element('encoding'))
         self.append(ET.Element('ontology'))
         self.append(ET.Element('protocol'))
         self.append(ET.Element('conversationID'))
@@ -517,7 +517,7 @@ class ACLMessage(ET.Element):
 if __name__ == '__main__':
 
     msg = ACLMessage()
-    msg.set_message('<?xml version="1.0" ?><ACLMessage"><performative>inform</performative><sender>Lucas@localhost:7352</sender><receivers><receiver>Allana@localhost:5851</receiver></receivers><reply-to/><content>51A Feeder 21I5</content><language/><enconding/><ontology/><protocol/><conversationID/><reply-with/><in-reply-to/><reply-by/></ACLMessage>')
+    msg.set_message('<?xml version="1.0" ?><ACLMessage"><performative>inform</performative><sender>Lucas@localhost:7352</sender><receivers><receiver>Allana@localhost:5851</receiver></receivers><reply-to/><content>51A Feeder 21I5</content><language/><encoding/><ontology/><protocol/><conversationID/><reply-with/><in-reply-to/><reply-by/></ACLMessage>')
     # msg.set_sender(AID(name='Lucas'))
     # msg.add_receiver(AID(name='Allana'))
     # msg.set_content('51A Feeder 21I5')


### PR DESCRIPTION
A little patch to fix all references to the misspelled word `enconding` => `encoding`.