### PR TITLE
Corrected Docker File

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,14 +1,16 @@
 FROM python:3.7
 
-MAINTAINER Pade Production <lucassmelo@dee.ufc.br>
+LABEL MAINTAINER="Pade Production <lucassmelo@dee.ufc.br>"
 
 LABEL Description="Framework for multiagent systems development in Python. This dockerfile builds a pade production environment."
 
 ENV  FLASK_ENV=production 
 ENV  FLASK_DEBUG=0
 
-RUN apt-get update && apt-get install -y python-pip python-dev build-essential python-pyside python-qt4reactor
-
+RUN apt-get update && apt-get install -y python-pip python-dev 
+RUN apt-get install -y build-essential python-qt4reactor 
+# RUN apt-get install -y python-pyside
+RUN pip3 install -U PySide2
 COPY . /app
 WORKDIR /app
 RUN python setup.py install


### PR DESCRIPTION
```apt-get python-pyside``` has been discontinued, so I have added the new way of installing the Pyside library to the docker file. 